### PR TITLE
Bug allow and stepping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,3 +14,4 @@ Environment Variables
 
 - ``VLAB_NTP_SERVER`` - The NTP server to use for synchronizing time.
 - ``VLAB_TIMEZONE`` - The local timezone of the vLab server.
+- ``VLAB_NTP_CLIENT_NETWORK`` - The network to allow NTP clients from in CIDR format

--- a/chrony.conf
+++ b/chrony.conf
@@ -3,7 +3,11 @@
 # /etc/chrony/chrony.conf
 # -rw-r--r-- root root
 
+# NTP servers to sync from
 server 0.us.pool.ntp.org
+
+# NTP clients to sync to
+allow 192.168.1.0/24
 
 # Enables kernel sync of the real-time clock (RTC)
 rtcsync

--- a/chrony.conf
+++ b/chrony.conf
@@ -11,3 +11,6 @@ allow 192.168.1.0/24
 
 # Enables kernel sync of the real-time clock (RTC)
 rtcsync
+
+# Allow Chrony to skip the clock ahead to fix large time skews
+makestep 500 10

--- a/config_and_run.sh
+++ b/config_and_run.sh
@@ -14,6 +14,16 @@ update_ntp_server() {
   fi
 }
 
+update_ntp_client_network() {
+  if [ ! -z ${VLAB_NTP_CLIENT_NETWORK+x} ]; then
+    echo "Allowing NTP clients on network" ${VLAB_NTP_CLIENT_NETWORK}
+    local netwk=$(echo ${VLAB_NTP_CLIENT_NETWORK} | sed 's/\//\\\//g')
+    sed -i -e "s/allow 192.168.1.0\/24/allow ${netwk}/g" /etc/chrony/chrony.conf
+  else
+    echo "Allowing default network access to NTP client"
+  fi
+}
+
 update_timezone() {
   if [ ! -z ${VLAB_TIMEZONE+x} ]; then
     echo "Using timezone" ${VLAB_TIMEZONE}
@@ -35,6 +45,7 @@ run_chrony() {
 
 main() {
   update_ntp_server
+  update_ntp_client_network
   update_timezone
   run_chrony
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,4 @@ services:
     environment:
       - VLAB_NTP_SERVER=3.us.pool.ntp.org
       - VLAB_TIMEZONE=America/Los_Angeles
+      - VLAB_NTP_CLIENT_NETWORK=10.25.1.0/24


### PR DESCRIPTION
This update enables Chrony to:

A) Act as an NTP server
B) Fix very large clock skews